### PR TITLE
95 1인1역 기능 개선

### DIFF
--- a/server/src/models/Student.js
+++ b/server/src/models/Student.js
@@ -41,8 +41,8 @@ const studentSchema = new Schema({
   icon: {
     type: Number,
   },
-  role: {
-    type: String,
+  roleHistory: {
+    type: [Number],
   },
 });
 

--- a/server/src/typeDefs-resolvers/roles/roles.js
+++ b/server/src/typeDefs-resolvers/roles/roles.js
@@ -92,12 +92,17 @@ const resolvers = {
 
     updateRoles: protectedMutation(async (_, { userEmail, order, startDate, endDate, data }) => {
       try {
-        await Roles.findOneAndUpdate(
-          { userEmail, "dates.order": order },
-          { $set: { "dates.$.startDate": startDate, "dates.$.endDate": endDate } },
-          { new: true },
-        );
-        // 역할(학생 명단) 수정 추가
+        if ((startDate, endDate)) {
+          await Roles.updateOne(
+            { userEmail, "dates.order": order },
+            { $set: { "dates.$.startDate": startDate, "dates.$.endDate": endDate } },
+          );
+        }
+        if (data) {
+          data.forEach(async ({ id, students }) => {
+            await Role.updateOne({ _id: id, "students.order": order }, { $set: { "students.$.students": students } });
+          });
+        }
         return { ok: true };
       } catch (err) {
         throw err.message;

--- a/server/src/typeDefs-resolvers/student/student.graphql
+++ b/server/src/typeDefs-resolvers/student/student.graphql
@@ -12,12 +12,17 @@ type Student {
   journal: [Journal]
   journalNum: Int
   icon: Int
-  role: String
+  roleHistory: [Int]
 }
 
 input StudentInfo {
   name: String!
   gender: String!
+}
+
+input RoleDoneInput {
+  id: String!
+  dates: [Int]
 }
 
 type Query {
@@ -44,10 +49,13 @@ type Mutation {
     icon: Int
     studentIcon: String
     restoreAll: Boolean
-    role: String
   ): mutationResult
 
   deleteStudent(disconnectOnly: Boolean!, teacherEmail: String!, studentId: ID!, listId: ID): mutationResult
 
   deleteAllStudent(teacherEmail: String!): mutationResult
+
+  checkRoleDone(teacherEmail: String!, data: [RoleDoneInput]): mutationResult
+
+  uncheckRoleDone(teacherEmail: String!, data: [RoleDoneInput]): mutationResult
 }

--- a/server/src/typeDefs-resolvers/student/student.js
+++ b/server/src/typeDefs-resolvers/student/student.js
@@ -116,7 +116,6 @@ const resolver = {
           memo,
           restoreAll,
           studentIcon,
-          role,
         },
       ) => {
         // 바꿀 이름이 이미 있는지 검사
@@ -165,7 +164,6 @@ const resolver = {
             $pull: { tag: delTag },
             memo,
             icon,
-            role,
           },
         );
         // 알러지 값이 있을 경우
@@ -219,6 +217,28 @@ const resolver = {
       }
       await Student.deleteMany({ teacherEmail, trash: true });
       return { ok: true };
+    }),
+
+    checkRoleDone: protectedMutation(async (_, { data }) => {
+      try {
+        data.forEach(async ({ id, dates }) => {
+          await Student.updateOne({ _id: id }, { $addToSet: { roleHistory: dates } });
+        });
+        return { ok: true };
+      } catch (err) {
+        throw err.message;
+      }
+    }),
+
+    uncheckRoleDone: protectedMutation(async (_, { data }) => {
+      try {
+        data.forEach(async ({ id, dates }) => {
+          await Student.updateOne({ _id: id }, { $pullAll: { roleHistory: dates } });
+        });
+        return { ok: true };
+      } catch (err) {
+        throw err.message;
+      }
     }),
   },
 };


### PR DESCRIPTION
1. 1인1역 수정 시 학생 명단 수정 기능
  - updateRoles 뮤테이션 사용 시 "data"인자로 역할(role) id와 학생 id 배열을 담은 객체를 배열에 담아 넘기면 해당 order의 학생 배열을 수정

2. 학생 데이터에서 1인1역 완료 날짜 체크 기능
  - checkRoleDone, uncheckRoleDone 뮤테이션 추가
  - 둘 다 "data" 인자로 학생 id와 날짜(int)를 담은 객체를 배열로 넘기면 해당 날짜를 추가 혹은 제거