### PR TITLE
1인1역 수정 기능에서 역할 추가 삭제 가능하게 개선

### DIFF
--- a/server/src/typeDefs-resolvers/roles/roles.graphql
+++ b/server/src/typeDefs-resolvers/roles/roles.graphql
@@ -46,7 +46,15 @@ type Mutation {
 
   addNewDateRoles(userEmail: String!, startDate: Float!, endDate: Float!, data: [RoleIdInput!]): mutationResult
 
-  updateRoles(userEmail: String!, order: Int!, startDate: Float, endDate: Float, data: [RoleIdInput]): mutationResult
+  updateRoles(
+    userEmail: String!
+    order: Int!
+    startDate: Float
+    endDate: Float
+    data: [RoleIdInput]
+    addRole: [RoleInput]
+    deleteRole: [ID]
+  ): mutationResult
 
   # addRole(userEmail: String!, data: [RoleInput!]): [Role]
 

--- a/server/src/typeDefs-resolvers/roles/roles.js
+++ b/server/src/typeDefs-resolvers/roles/roles.js
@@ -90,7 +90,7 @@ const resolvers = {
       }
     }),
 
-    updateRoles: protectedMutation(async (_, { userEmail, order, startDate, endDate, data }) => {
+    updateRoles: protectedMutation(async (_, { userEmail, order, startDate, endDate, data, addRole, deleteRole }) => {
       try {
         if ((startDate, endDate)) {
           await Roles.updateOne(
@@ -102,6 +102,19 @@ const resolvers = {
           data.forEach(async ({ id, students }) => {
             await Role.updateOne({ _id: id, "students.order": order }, { $set: { "students.$.students": students } });
           });
+        }
+        if (addRole) {
+          const { _id } = await Roles.findOne({ userEmail });
+          const convertedData = addRole.map(({ title, detail, students }) => ({
+            title,
+            detail,
+            roles: _id,
+            students: { order, students },
+          }));
+          await Role.insertMany(convertedData);
+        }
+        if (deleteRole) {
+          await Role.deleteMany({ _id: { $in: deleteRole } });
         }
         return { ok: true };
       } catch (err) {


### PR DESCRIPTION
updateRoles 뮤테이션에서 역할 추가 및 삭제 기능 추가
1. `addRole` 인자로 `RoleInput` 을 담은 배열을 (`createRoles` 처럼)넘기면 해당 1인1역에 해당 `order` 값으로 역할(학생 포함) 추가
2. `deleteRole` 인자로 삭제할 역할들의 id를 배열에 담아 넘기면 해당 역할들 삭제

updateRoles 뮤테이션 요청 한 번으로
1. 1인1역 기간 변경 가능
2. 해당 1인1역에 존재하는 역할의 학생 수정 가능
3. 새로운 역할(학생 담아서) 추가 가능
4. 기존 역할 삭제 가능